### PR TITLE
Block suspicious redirect urls

### DIFF
--- a/source.txt
+++ b/source.txt
@@ -3158,3 +3158,4 @@
 *://*.zgxchatfin.top/
 *://*.zjfcontracthan.top/
 *://*.zntexchangeliu.top/
+/^https?:\/\/[^/]+\/.*(R(URL|EDIRECT)|FILE(?:NAME)?|UR[LI]|DEST(?:INATION)?|LINK)=.*\//i


### PR DESCRIPTION
以下のような、リダイレクトパラメーターを仕込んだ SEO スパムが散見されます。

```
https://kenkyuukai.m3.com/API/PreSocietyLoginState.asp?rurl=//subgracathinkpaterk.tk/137q43kenkyuukaim3com68q
https://tochigi-vnpo.net/db/topics/topics_data_count.html?code=262&file=//finleuconta.ga/s26dmon43tochigi-vnponeta2
https://sp-web.search.auone.jp/redirect?url=//avlevemagtilo.ml/b80sp-websearchauonejpaTc400
https://www.dioptra.gr/BannerClick.php?BannerID=50&LocationURL=//subgracathinkpaterk.tk/113wwwdioptragrdTa651
https://marciatravessoni.com.br/revive/www/delivery/ck.php?ct=1&91b8a2fb__oadest=//subgracathinkpaterk.tk/143marciatravessonicombrA26380
```

ちゃんとしたウェブページであれば、httpd.conf、.htaccess、メタタグなど何らかのマッピングでリダイレクトを実装するはず。
ウェブページの URL に、外部ドメインへのリダイレクト用パラメーターを含めることは通常考えにくいでしょう。



